### PR TITLE
fix: Fixes #3348. Add missing `.net` to documentation examples

### DIFF
--- a/docs/include_package-net.rst
+++ b/docs/include_package-net.rst
@@ -66,7 +66,7 @@ Example
 
 .. code-block:: javascript
 
-    web3.eth.isListening()
+    web3.eth.net.isListening()
     .then(console.log);
     > true
 
@@ -101,6 +101,6 @@ Example
 
 .. code-block:: javascript
 
-    web3.eth.getPeerCount()
+    web3.eth.net.getPeerCount()
     .then(console.log);
     > 25


### PR DESCRIPTION
## Description

Please include a summary of the change and be sure you follow the contributions rules we do provide [here](./CONTRIBUTIONS.md)

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code on the live network.
